### PR TITLE
feat: add Quarto Wizard schema and snippets

### DIFF
--- a/_extensions/appearance/_schema.yml
+++ b/_extensions/appearance/_schema.yml
@@ -1,0 +1,75 @@
+$schema: https://m.canouil.dev/quarto-wizard/assets/schema/v1/extension-schema.json
+
+formats:
+  revealjs:
+    appearance:
+      type: object
+      description: Configuration for the Appearance reveal.js plugin.
+      properties:
+        hideagain:
+          type: boolean
+          default: true
+          description: Re-hide animated elements when navigating backwards.
+        delay:
+          type: integer
+          default: 300
+          min: 0
+          description: Base delay in milliseconds between element appearances.
+        debug:
+          type: boolean
+          default: false
+          description: Enable debug logging.
+        appearevent:
+          type: string
+          default: slidetransitionend
+          enum: [slidetransitionend, slidechanged, auto]
+          description: Reveal event used to start appearance animations.
+        autoappear:
+          type: boolean
+          default: false
+          description: Automatically apply animation classes to selected elements.
+        autoelements:
+          type: [object, string]
+          description: Selector-to-animation mapping for autoappear mode.
+        appearparents:
+          type: boolean
+          default: false
+          description: Apply animation handling to wrapped list item parents.
+        initdelay:
+          type: integer
+          default: 0
+          min: 0
+          description: Delay in milliseconds before the first animation sequence.
+
+attributes:
+  _any:
+    data-appear-parent:
+      type: boolean
+      description: Animate parent list marker when Quarto wraps list content in spans.
+    data-split:
+      type: string
+      enum: [words, letters]
+      description: Split animated text into words or letters.
+    data-delay:
+      type: integer
+      min: 0
+      description: Delay in milliseconds before this element appears.
+    data-container-delay:
+      type: integer
+      min: 0
+      description: Delay in milliseconds before the first item in a container appears.
+    data-autoappear:
+      type: [boolean, string]
+      description: Enable local autoappear mode or provide selector animation mapping.
+    data-appearevent:
+      type: string
+      enum: [slidetransitionend, slidechanged, auto, autoanimate]
+      description: Override appearance trigger event for a specific slide.
+
+classes:
+  animate__fadeInLeft:
+    description: Animate.css entrance class commonly used with Appearance.
+  animate__fadeInDown:
+    description: Animate.css entrance class commonly used with Appearance.
+  animate__bounceInLeft:
+    description: Animate.css entrance class commonly used with Appearance.

--- a/_extensions/appearance/_snippets.json
+++ b/_extensions/appearance/_snippets.json
@@ -1,0 +1,22 @@
+{
+  "Appearance config": {
+    "prefix": "appearance-config",
+    "body": [
+      "format:",
+      "  revealjs:",
+      "    appearance:",
+      "      autoappear: ${1:true}",
+      "      autoelements: {\"ul li\": \"animate__fadeInLeft\"}",
+      "revealjs-plugins:",
+      "  - appearance"
+    ],
+    "description": "Insert Appearance plugin settings for revealjs."
+  },
+  "Animated span": {
+    "prefix": "animated-span",
+    "body": [
+      "[${1:Animated text}]{.${2:animate__fadeInDown} data-delay=\"${3:200}\"}"
+    ],
+    "description": "Insert inline text with an Animate.css class and optional delay."
+  }
+}

--- a/_extensions/appearance/_snippets.json
+++ b/_extensions/appearance/_snippets.json
@@ -1,6 +1,6 @@
 {
   "Appearance config": {
-    "prefix": "appearance-config",
+    "prefix": "config",
     "body": [
       "format:",
       "  revealjs:",
@@ -13,7 +13,7 @@
     "description": "Insert Appearance plugin settings for revealjs."
   },
   "Animated span": {
-    "prefix": "animated-span",
+    "prefix": "span",
     "body": [
       "[${1:Animated text}]{.${2:animate__fadeInDown} data-delay=\"${3:200}\"}"
     ],


### PR DESCRIPTION
This PR improves Quarto Wizard support (VS Code/Positron) for this extension by adding extension metadata files used for editor assistance.

### What this adds
- `_schema.yml` with extension-specific fields (options/classes/attributes and/or format keys) to enable better completion, hover docs, and validation.
- `_snippets.json` with practical insertion snippets for common extension usage.

### Why
These files improve authoring UX in Quarto projects by making extension configuration and usage easier to discover and less error-prone in VSCode/Positron when using Quarto Wizard.

### References
- Schema specification: https://m.canouil.dev/quarto-wizard/reference/schema-specification.html
- Snippet specification: https://m.canouil.dev/quarto-wizard/reference/snippet-specification.html